### PR TITLE
GitHub Action time limit

### DIFF
--- a/.github/workflows/ruby_ci.yml
+++ b/.github/workflows/ruby_ci.yml
@@ -15,6 +15,7 @@ jobs:
   test:
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Limit each matrix test run to 3 minutes which is plenty of time.