### PR TITLE
Treetop upgrade

### DIFF
--- a/dmn/dmn.gemspec
+++ b/dmn/dmn.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activemodel", ENV.fetch("RAILS_VERSION", ">= 6.0")
   spec.add_dependency "activesupport", ENV.fetch("RAILS_VERSION", ">= 6.0")
   spec.add_dependency "ostruct"
-  spec.add_dependency "treetop", ">= 1.6.12"
   spec.add_dependency "xmlhasher", "~> 1.0.7"
 
   spec.add_development_dependency "rake"

--- a/dmn/dmn.gemspec
+++ b/dmn/dmn.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activemodel", ENV.fetch("RAILS_VERSION", ">= 6.0")
   spec.add_dependency "activesupport", ENV.fetch("RAILS_VERSION", ">= 6.0")
   spec.add_dependency "ostruct"
-  spec.add_dependency "treetop", "=1.6.12" # locked as treetop made some class changes that cause: superclass mismatch for class Parser (TypeError)
+  spec.add_dependency "treetop", ">= 1.6.12"
   spec.add_dependency "xmlhasher", "~> 1.0.7"
 
   spec.add_development_dependency "rake"

--- a/feel/feel.gemspec
+++ b/feel/feel.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activemodel", ENV.fetch("RAILS_VERSION", ">= 6.0")
   spec.add_dependency "activesupport", ENV.fetch("RAILS_VERSION", ">= 6.0")
   spec.add_dependency "ostruct"
-  spec.add_dependency "treetop", "=1.6.12" # locked as treetop made some class changes that cause: superclass mismatch for class Parser (TypeError)
+  spec.add_dependency "treetop", ">= 1.6.12"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "guard"

--- a/feel/lib/feel/parser.rb
+++ b/feel/lib/feel/parser.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module FEEL
+  # Load the Treetop grammar which defines FEEL::Parser < Treetop::Runtime::CompiledParser
+  Treetop.load(File.expand_path(File.join(File.dirname(__FILE__), "feel.treetop")))
+
+  # Reopen the Treetop-generated Parser class to add convenience methods
   class Parser
-    # Load the Treetop grammar from the 'feel' file, and create a new
-    # instance of that parser as a class variable so we don't have to re-create
-    # it every time we need to parse a string
-    Treetop.load(File.expand_path(File.join(File.dirname(__FILE__), "feel.treetop")))
-    @@parser = FEELParser.new
+    @@parser = new
 
     def self.parse(expression, root: nil)
       @@parser.parse(expression, root: root).tap do |ast|


### PR DESCRIPTION
Address issue with superclass mismatch and relax treetop dependency.

Additionally we remove the treetop dependency from `dmn` as it is only used by `feel`.