### PR TITLE
Null Operands

### DIFF
--- a/feel/lib/feel/feel.treetop
+++ b/feel/lib/feel/feel.treetop
@@ -270,7 +270,9 @@ grammar FEEL
   rule arithmetic_negation
     "-" __ "(" __ expr:expression __ ")" {
       def eval(context={})
-        -expr.eval(context)
+        val = expr.eval(context)
+        return nil if val.nil?
+        -val
       end
     }
   end

--- a/feel/lib/feel/nodes.rb
+++ b/feel/lib/feel/nodes.rb
@@ -84,13 +84,13 @@ module FEEL
 
       case operator
       when "<"
-        ->(input) { input < endpoint }
+        ->(input) { input.nil? || endpoint.nil? ? nil : input < endpoint }
       when "<="
-        ->(input) { input <= endpoint }
+        ->(input) { input.nil? || endpoint.nil? ? nil : input <= endpoint }
       when ">"
-        ->(input) { input > endpoint }
+        ->(input) { input.nil? || endpoint.nil? ? nil : input > endpoint }
       when ">="
-        ->(input) { input >= endpoint }
+        ->(input) { input.nil? || endpoint.nil? ? nil : input >= endpoint }
       else
         ->(input) { input == endpoint }
       end

--- a/feel/lib/feel/nodes.rb
+++ b/feel/lib/feel/nodes.rb
@@ -265,7 +265,7 @@ module FEEL
       head_val = head.eval(context)
       tail_val = tail.eval(context)
       return nil if head_val.nil? || tail_val.nil?
-      head.eval(context) + tail.eval(context)
+      head_val + tail_val
     end
   end
 

--- a/feel/lib/feel/nodes.rb
+++ b/feel/lib/feel/nodes.rb
@@ -274,7 +274,10 @@ module FEEL
   #
   class Subtraction < Node
     def eval(context = {})
-      head.eval(context) - tail.eval(context)
+      head_val = head.eval(context)
+      tail_val = tail.eval(context)
+      return nil if head_val.nil? || tail_val.nil?
+      head_val - tail_val
     end
   end
 
@@ -283,7 +286,10 @@ module FEEL
   #
   class Multiplication < Node
     def eval(context = {})
-      head.eval(context) * tail.eval(context)
+      head_val = head.eval(context)
+      tail_val = tail.eval(context)
+      return nil if head_val.nil? || tail_val.nil?
+      head_val * tail_val
     end
   end
 
@@ -292,7 +298,10 @@ module FEEL
   #
   class Division < Node
     def eval(context = {})
-      head.eval(context) / tail.eval(context)
+      head_val = head.eval(context)
+      tail_val = tail.eval(context)
+      return nil if head_val.nil? || tail_val.nil?
+      head_val / tail_val
     end
   end
 
@@ -301,7 +310,10 @@ module FEEL
   #
   class Exponentiation < Node
     def eval(context = {})
-      head.eval(context) ** tail.eval(context)
+      head_val = head.eval(context)
+      tail_val = tail.eval(context)
+      return nil if head_val.nil? || tail_val.nil?
+      head_val ** tail_val
     end
   end
 

--- a/feel/lib/feel/nodes.rb
+++ b/feel/lib/feel/nodes.rb
@@ -112,16 +112,17 @@ module FEEL
       finish = end_token.text_value
       first_val = first.eval(context)
       second_val = second.eval(context)
+      return ->(_input) { nil } if first_val.nil? || second_val.nil?
 
       case [start, finish]
       when ["(", ")"]
-        ->(input) { first_val < input && input < second_val }
+        ->(input) { input.nil? ? nil : first_val < input && input < second_val }
       when ["[", "]"]
-        ->(input) { first_val <= input && input <= second_val }
+        ->(input) { input.nil? ? nil : first_val <= input && input <= second_val }
       when ["(", "]"]
-        ->(input) { first_val < input && input <= second_val }
+        ->(input) { input.nil? ? nil : first_val < input && input <= second_val }
       when ["[", ")"]
-        ->(input) { first_val <= input && input < second_val }
+        ->(input) { input.nil? ? nil : first_val <= input && input < second_val }
       end
     end
   end
@@ -561,13 +562,14 @@ module FEEL
   #
   class Comparison < Node
     def eval(context = {})
+      left_val = left.eval(context)
+      right_val = right.eval(context)
       case operator.text_value
-      when "<" then left.eval(context) < right.eval(context)
-      when "<=" then left.eval(context) <= right.eval(context)
-      when ">=" then left.eval(context) >= right.eval(context)
-      when ">" then left.eval(context) > right.eval(context)
-      when "!=" then left.eval(context) != right.eval(context)
-      when "=" then left.eval(context) == right.eval(context)
+      when "<", "<=", ">=", ">"
+        return nil if left_val.nil? || right_val.nil?
+        left_val.send(operator.text_value, right_val)
+      when "!=" then left_val != right_val
+      when "=" then left_val == right_val
       end
     end
   end

--- a/feel/test/feel/literal_expression_test.rb
+++ b/feel/test/feel/literal_expression_test.rb
@@ -190,8 +190,28 @@ module FEEL
         _(LiteralExpression.new(text: "2 + (3 + 3)").evaluate).must_equal 8
       end
 
-      it "should handle null operands" do
+      it "should handle null operands in addition" do
         _(LiteralExpression.new(text: "1 + null").evaluate).must_be_nil
+      end
+
+      it "should handle null operands in subtraction" do
+        _(LiteralExpression.new(text: "1 - null").evaluate).must_be_nil
+      end
+
+      it "should handle null operands in multiplication" do
+        _(LiteralExpression.new(text: "2 * null").evaluate).must_be_nil
+      end
+
+      it "should handle null operands in division" do
+        _(LiteralExpression.new(text: "6 / null").evaluate).must_be_nil
+      end
+
+      it "should handle null operands in exponentiation" do
+        _(LiteralExpression.new(text: "2 ** null").evaluate).must_be_nil
+      end
+
+      it "should handle missing variables in arithmetic" do
+        _(LiteralExpression.new(text: "a - b").evaluate).must_be_nil
       end
     end
 

--- a/feel/test/feel/literal_expression_test.rb
+++ b/feel/test/feel/literal_expression_test.rb
@@ -250,6 +250,18 @@ module FEEL
         _(LiteralExpression.new(text: "null = null").evaluate).must_equal true
         _(LiteralExpression.new(text: "1 = null").evaluate).must_equal false
       end
+
+      it "should handle null operands in ordering comparisons" do
+        _(LiteralExpression.new(text: "1 < null").evaluate).must_be_nil
+        _(LiteralExpression.new(text: "null < 1").evaluate).must_be_nil
+        _(LiteralExpression.new(text: "1 <= null").evaluate).must_be_nil
+        _(LiteralExpression.new(text: "1 > null").evaluate).must_be_nil
+        _(LiteralExpression.new(text: "1 >= null").evaluate).must_be_nil
+      end
+
+      it "should handle missing variables in comparisons" do
+        _(LiteralExpression.new(text: "a < b").evaluate).must_be_nil
+      end
     end
 
     describe :qualified_name do

--- a/feel/test/feel/literal_expression_test.rb
+++ b/feel/test/feel/literal_expression_test.rb
@@ -839,6 +839,10 @@ module FEEL
       it "should eval a nested mathematic operation" do
         _(LiteralExpression.new(text: "-(1 + (3 * 5))").evaluate).must_equal(-16)
       end
+
+      it "should handle null in arithmetic negation" do
+        _(LiteralExpression.new(text: "-(null)").evaluate).must_be_nil
+      end
     end
   end
 end

--- a/feel/test/feel/unary_tests_test.rb
+++ b/feel/test/feel/unary_tests_test.rb
@@ -56,5 +56,27 @@ module FEEL
         _(UnaryTests.new(text: "not(2,3)").test(1)).must_equal true
       end
     end
+
+    describe :null_handling do
+      it "should not match null input in comparisons" do
+        _(UnaryTests.new(text: "< 4").test(nil)).must_equal false
+        _(UnaryTests.new(text: "<= 4").test(nil)).must_equal false
+        _(UnaryTests.new(text: "> 4").test(nil)).must_equal false
+        _(UnaryTests.new(text: ">= 4").test(nil)).must_equal false
+      end
+
+      it "should not match null endpoint in comparisons" do
+        _(UnaryTests.new(text: "< null").test(3)).must_equal false
+      end
+
+      it "should not match null in intervals" do
+        _(UnaryTests.new(text: "[null..4]").test(3)).must_equal false
+        _(UnaryTests.new(text: "[2..null]").test(3)).must_equal false
+      end
+
+      it "should not match null input in intervals" do
+        _(UnaryTests.new(text: "[2..4]").test(nil)).must_equal false
+      end
+    end
   end
 end


### PR DESCRIPTION
Changes many operations to handle null operands per the spec. Ex: `1 + null = null` and `1 < null => null`.

Probably still haven't caught all the scenarios, but this is quite a bit more.