### PR TITLE
Order of Operations and Associativity

### DIFF
--- a/feel/lib/feel/feel.treetop
+++ b/feel/lib/feel/feel.treetop
@@ -60,6 +60,40 @@ grammar FEEL
     bracketed_arithmetic_expression
   end
 
+  # Precedence hierarchy used within operator rules (low to high):
+  #   additive > multiplicative > exponential > atom
+
+  rule additive_expression
+    addition /
+    subtraction /
+    multiplicative_expression
+  end
+
+  rule multiplicative_expression
+    multiplication /
+    division /
+    exponential_expression
+  end
+
+  rule exponential_expression
+    exponentiation /
+    arithmetic_atom
+  end
+
+  rule arithmetic_atom
+    arithmetic_negation /
+    bracketed_additive_expression /
+    simple_value
+  end
+
+  rule bracketed_additive_expression
+    "(" __ additive_expression __ ")" {
+      def eval(context={})
+        additive_expression.eval(context)
+      end
+    }
+  end
+
   rule bracketed_arithmetic_expression
     "(" __ arithmetic_expression __ ")" {
       def eval(context={})
@@ -223,12 +257,7 @@ grammar FEEL
   # 21. addition = expression , "+" , expression ;
   #
   rule addition
-    head:non_recursive_simple_expression_for_arithmetic_expression __ "+" __ tail:expression <Addition>
-  end
-
-  rule non_recursive_simple_expression_for_arithmetic_expression
-    bracketed_arithmetic_expression /
-    simple_value
+    head:multiplicative_expression __ "+" __ tail:additive_expression <Addition>
   end
 
   rule non_recursive_simple_expression_for_comparison
@@ -240,28 +269,28 @@ grammar FEEL
   # 22. subtraction = expression , "-" , expression ;
   #
   rule subtraction
-    head:non_recursive_simple_expression_for_arithmetic_expression __ "-" __ tail:expression <Subtraction>
+    head:multiplicative_expression __ "-" __ tail:additive_expression <Subtraction>
   end
 
   #
   # 23. multiplication = expression , "\*" , expression ;
   #
   rule multiplication
-    head:non_recursive_simple_expression_for_arithmetic_expression __ "*" __ tail:expression <Multiplication>
+    head:exponential_expression __ "*" !"*" __ tail:multiplicative_expression <Multiplication>
   end
 
   #
   # 24. division = expression , "/" , expression ;
   #
   rule division
-    head:non_recursive_simple_expression_for_arithmetic_expression __ "/" __ tail:expression <Division>
+    head:exponential_expression __ "/" __ tail:multiplicative_expression <Division>
   end
 
   #
   # 25. exponentiation = expression, "\*\*", expression ;
   #
   rule exponentiation
-    head:non_recursive_simple_expression_for_arithmetic_expression __ "**" __ tail:expression <Exponentiation>
+    head:arithmetic_atom __ "**" __ tail:exponential_expression <Exponentiation>
   end
 
   #

--- a/feel/lib/feel/feel.treetop
+++ b/feel/lib/feel/feel.treetop
@@ -51,10 +51,8 @@ grammar FEEL
   # 4.d arithmetic negation ;
   #
   rule arithmetic_expression
-    addition /
-    subtraction /
-    multiplication /
-    division /
+    additive_operation /
+    multiplicative_operation /
     exponentiation /
     arithmetic_negation /
     bracketed_arithmetic_expression
@@ -64,15 +62,59 @@ grammar FEEL
   #   additive > multiplicative > exponential > atom
 
   rule additive_expression
-    addition /
-    subtraction /
+    additive_operation /
     multiplicative_expression
   end
 
   rule multiplicative_expression
-    multiplication /
-    division /
+    multiplicative_operation /
     exponential_expression
+  end
+
+  #
+  # 21. addition = expression , "+" , expression ;
+  # 22. subtraction = expression , "-" , expression ;
+  #
+  rule additive_operation
+    head:multiplicative_expression tail:(__ op:("+" / "-") __ multiplicative_expression)+ {
+      def eval(context={})
+        result = head.eval(context)
+        tail.elements.each do |e|
+          operand = e.multiplicative_expression.eval(context)
+          if e.op.text_value == "+"
+            return nil if result.nil? || operand.nil?
+            result = result + operand
+          else
+            return nil if result.nil? || operand.nil?
+            result = result - operand
+          end
+        end
+        result
+      end
+    }
+  end
+
+  #
+  # 23. multiplication = expression , "\*" , expression ;
+  # 24. division = expression , "/" , expression ;
+  #
+  rule multiplicative_operation
+    head:exponential_expression tail:(__ op:("*" !"*" / "/") __ exponential_expression)+ {
+      def eval(context={})
+        result = head.eval(context)
+        tail.elements.each do |e|
+          operand = e.exponential_expression.eval(context)
+          if e.op.text_value.start_with?("*")
+            return nil if result.nil? || operand.nil?
+            result = result * operand
+          else
+            return nil if result.nil? || operand.nil?
+            result = result / operand
+          end
+        end
+        result
+      end
+    }
   end
 
   rule exponential_expression
@@ -253,37 +295,9 @@ grammar FEEL
     head:name tail:(__ "." __ name)* <QualifiedName>
   end
 
-  #
-  # 21. addition = expression , "+" , expression ;
-  #
-  rule addition
-    head:multiplicative_expression __ "+" __ tail:additive_expression <Addition>
-  end
-
   rule non_recursive_simple_expression_for_comparison
     arithmetic_expression /
     simple_value
-  end
-
-  #
-  # 22. subtraction = expression , "-" , expression ;
-  #
-  rule subtraction
-    head:multiplicative_expression __ "-" __ tail:additive_expression <Subtraction>
-  end
-
-  #
-  # 23. multiplication = expression , "\*" , expression ;
-  #
-  rule multiplication
-    head:exponential_expression __ "*" !"*" __ tail:multiplicative_expression <Multiplication>
-  end
-
-  #
-  # 24. division = expression , "/" , expression ;
-  #
-  rule division
-    head:exponential_expression __ "/" __ tail:multiplicative_expression <Division>
   end
 
   #

--- a/feel/lib/feel/nodes.rb
+++ b/feel/lib/feel/nodes.rb
@@ -308,54 +308,6 @@ module FEEL
   end
 
   #
-  # 21. addition = expression , "+" , expression ;
-  #
-  class Addition < Node
-    def eval(context = {})
-      head_val = head.eval(context)
-      tail_val = tail.eval(context)
-      return nil if head_val.nil? || tail_val.nil?
-      head_val + tail_val
-    end
-  end
-
-  #
-  # 22. subtraction = expression , "-" , expression ;
-  #
-  class Subtraction < Node
-    def eval(context = {})
-      head_val = head.eval(context)
-      tail_val = tail.eval(context)
-      return nil if head_val.nil? || tail_val.nil?
-      head_val - tail_val
-    end
-  end
-
-  #
-  # 23. multiplication = expression , "\*" , expression ;
-  #
-  class Multiplication < Node
-    def eval(context = {})
-      head_val = head.eval(context)
-      tail_val = tail.eval(context)
-      return nil if head_val.nil? || tail_val.nil?
-      head_val * tail_val
-    end
-  end
-
-  #
-  # 24. division = expression , "/" , expression ;
-  #
-  class Division < Node
-    def eval(context = {})
-      head_val = head.eval(context)
-      tail_val = tail.eval(context)
-      return nil if head_val.nil? || tail_val.nil?
-      head_val / tail_val
-    end
-  end
-
-  #
   # 25. exponentiation = expression, "\*\*", expression ;
   #
   class Exponentiation < Node

--- a/feel/test/feel/literal_expression_test.rb
+++ b/feel/test/feel/literal_expression_test.rb
@@ -277,6 +277,31 @@ module FEEL
         it "should respect all precedence levels together" do
           _(LiteralExpression.new(text: "1 + 2 ** 3 * 4 - 10 / 2").evaluate).must_equal 28
         end
+
+        it "should evaluate subtraction left-to-right (left-associative)" do
+          _(LiteralExpression.new(text: "10 - 3 - 2").evaluate).must_equal 5
+          _(LiteralExpression.new(text: "20 - 5 - 3 - 2").evaluate).must_equal 10
+        end
+
+        it "should evaluate division left-to-right (left-associative)" do
+          _(LiteralExpression.new(text: "24 / 4 / 2").evaluate).must_equal 3
+          _(LiteralExpression.new(text: "120 / 6 / 4 / 5").evaluate).must_equal 1
+        end
+
+        it "should handle mixed addition and subtraction left-to-right" do
+          _(LiteralExpression.new(text: "10 - 3 + 2").evaluate).must_equal 9
+          _(LiteralExpression.new(text: "10 + 3 - 2").evaluate).must_equal 11
+        end
+
+        it "should handle mixed multiplication and division left-to-right" do
+          _(LiteralExpression.new(text: "24 / 4 * 2").evaluate).must_equal 12
+          _(LiteralExpression.new(text: "6 * 4 / 8").evaluate).must_equal 3
+        end
+
+        it "should evaluate exponentiation right-to-left (right-associative)" do
+          # 2 ** 3 ** 2 = 2 ** (3 ** 2) = 2 ** 9 = 512
+          _(LiteralExpression.new(text: "2 ** 3 ** 2").evaluate).must_equal 512
+        end
       end
     end
 

--- a/feel/test/feel/literal_expression_test.rb
+++ b/feel/test/feel/literal_expression_test.rb
@@ -241,6 +241,43 @@ module FEEL
       it "should handle missing variables in arithmetic" do
         _(LiteralExpression.new(text: "a - b").evaluate).must_be_nil
       end
+
+      describe "order of operations" do
+        it "should evaluate multiplication before addition" do
+          _(LiteralExpression.new(text: "2 * 3 + 4").evaluate).must_equal 10
+          _(LiteralExpression.new(text: "2 + 3 * 4").evaluate).must_equal 14
+        end
+
+        it "should evaluate multiplication before subtraction" do
+          _(LiteralExpression.new(text: "2 * 3 - 1").evaluate).must_equal 5
+          _(LiteralExpression.new(text: "10 - 2 * 3").evaluate).must_equal 4
+        end
+
+        it "should evaluate division before addition" do
+          _(LiteralExpression.new(text: "6 / 2 + 1").evaluate).must_equal 4
+          _(LiteralExpression.new(text: "2 + 6 / 2").evaluate).must_equal 5
+        end
+
+        it "should evaluate exponentiation before addition" do
+          _(LiteralExpression.new(text: "2 ** 3 + 1").evaluate).must_equal 9
+          _(LiteralExpression.new(text: "1 + 2 ** 3").evaluate).must_equal 9
+        end
+
+        it "should evaluate exponentiation before multiplication" do
+          _(LiteralExpression.new(text: "2 ** 3 * 2").evaluate).must_equal 16
+          _(LiteralExpression.new(text: "2 * 2 ** 3").evaluate).must_equal 16
+        end
+
+        it "should respect parentheses overriding precedence" do
+          _(LiteralExpression.new(text: "(2 + 3) * 4").evaluate).must_equal 20
+          _(LiteralExpression.new(text: "2 * (3 + 4)").evaluate).must_equal 14
+        end
+
+        # 1 + 2 ** 3 * 4 - 10 / 2 = 1 + (2**3) * 4 - (10/2) = 1 + 8*4 - 5 = 1 + 32 - 5 = 28
+        it "should respect all precedence levels together" do
+          _(LiteralExpression.new(text: "1 + 2 ** 3 * 4 - 10 / 2").evaluate).must_equal 28
+        end
+      end
     end
 
     describe :comparison do


### PR DESCRIPTION
Changes the grammer for deterministic and typical processing of math using order of operations and left-associativity.

### Order-of-Operations
**Expression:** `10 + 5 * 3 - 8 / 2`

| | Evaluation | Result |
|---|---|---|
| **Before** (no precedence) | `10 + (5 * (3 - (8 / 2)))` → `10 + (5 * -1)` | `5` |
| **After** (correct precedence) | `10 + (5 * 3) - (8 / 2)` → `10 + 15 - 4` | `21` |

### Left-Associative
**Expression:** `100 - 30 - 20 + 5`
| | Evaluation | Result |
|---|---|---|
| **Before** (right-associative) | `100 - (30 - (20 + 5))` → `100 - 5` | `95` |
| **After** (left-associative) | `((100 - 30) - 20) + 5` → `50 + 5` | `55` |