### PR TITLE
Fix FEEL expression handling

### DIFF
--- a/bpmn/lib/bpmn/execution.rb
+++ b/bpmn/lib/bpmn/execution.rb
@@ -171,11 +171,15 @@ module BPMN
     end
 
     def evaluate_condition(condition)
-      evaluate_expression(condition.delete_prefix("=")) == true
+      evaluate_expression(condition) == true
     end
 
     def evaluate_expression(expression, variables: parent&.variables || {}.with_indifferent_access)
-      DMN.evaluate(expression.delete_prefix("="), variables: variables)
+      if expression.start_with?("=")
+        DMN.evaluate(expression.delete_prefix("="), variables: variables)
+      else
+        expression
+      end
     end
 
     def run_automated_tasks

--- a/bpmn/lib/bpmn/execution.rb
+++ b/bpmn/lib/bpmn/execution.rb
@@ -175,6 +175,8 @@ module BPMN
     end
 
     def evaluate_expression(expression, variables: parent&.variables || {}.with_indifferent_access)
+      return nil if expression.nil?
+
       if expression.start_with?("=")
         DMN.evaluate(expression.delete_prefix("="), variables: variables)
       else

--- a/bpmn/lib/bpmn/process.rb
+++ b/bpmn/lib/bpmn/process.rb
@@ -162,11 +162,10 @@ module BPMN
     attr_reader :process_id
 
     def execute(execution)
-      if extension_elements&.called_element&.process_id&.start_with?("=")
-        @process_id = DMN.evaluate(extension_elements&.called_element&.process_id, variables: execution.variables)
-      else
-        @process_id = extension_elements&.called_element&.process_id
-      end
+      @process_id = execution.evaluate_expression(
+        extension_elements&.called_element&.process_id,
+        variables: execution.variables
+      )
 
       execution.wait
 

--- a/bpmn/lib/bpmn/task.rb
+++ b/bpmn/lib/bpmn/task.rb
@@ -105,7 +105,7 @@ module BPMN
     end
 
     def run(execution)
-      DMN.evaluate(script.delete_prefix("="), variables: execution.parent.variables)
+      execution.parent.evaluate_expression(script, variables: execution.parent.variables)
     end
   end
 

--- a/bpmn/test/bpmn/execution_test.rb
+++ b/bpmn/test/bpmn/execution_test.rb
@@ -55,6 +55,10 @@ module BPMN
         _(catch_event.waiting?).must_equal true
       end
 
+      it "should handle nil expressions" do
+        _(execution.evaluate_expression(nil)).must_be_nil
+      end
+
       describe :catch_and_bypass do
         before { catch_event.signal }
 

--- a/bpmn/test/fixtures/files/graffiti.bpmn
+++ b/bpmn/test/fixtures/files/graffiti.bpmn
@@ -63,16 +63,16 @@
     <bpmn:sequenceFlow id="Flow_29280" sourceRef="graffiti_close_ticket" targetRef="graffiti_end" />
     <bpmn:sequenceFlow id="Flow_29180" sourceRef="graffiti_closed" targetRef="graffiti_end" />
     <bpmn:sequenceFlow id="Flow_29220" sourceRef="graffiti_inspect" targetRef="graffiti_close_ticket">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">"not_found = data.graffiti_inspect_outcome"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">="not_found" = data.graffiti_inspect_outcome</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_29240" sourceRef="graffiti_inspect" targetRef="graffiti_remove">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">"ready = data.graffiti_inspect_outcome"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">="ready" = data.graffiti_inspect_outcome</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_29260" sourceRef="graffiti_remove" targetRef="graffiti_close_ticket">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">"removed = data.graffiti_remove_outcome"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">="removed" = data.graffiti_remove_outcome</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_29200" sourceRef="graffiti_remove" targetRef="graffiti_inspect">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">"help_wanted = data.graffiti_remove_outcome"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">="help_wanted" = data.graffiti_remove_outcome</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_29300" sourceRef="graffiti_close_ticket" targetRef="graffiti_end" />
     <bpmn:sequenceFlow id="Flow_29140" sourceRef="parallel_gateway" targetRef="graffiti_closed" />

--- a/bpmn/test/fixtures/files/inclusive_gateway_test.bpmn
+++ b/bpmn/test/fixtures/files/inclusive_gateway_test.bpmn
@@ -26,14 +26,14 @@
       <bpmn:outgoing>Flow_8</bpmn:outgoing>
     </bpmn:task>
     <bpmn:sequenceFlow id="Flow_4" sourceRef="Split" targetRef="CheckPrinterParts">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">include_printer_parts = true</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=include_printer_parts = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:task id="CheckLaptopParts" name="Check Laptop Parts">
       <bpmn:incoming>Flow_5</bpmn:incoming>
       <bpmn:outgoing>Flow_6</bpmn:outgoing>
     </bpmn:task>
     <bpmn:sequenceFlow id="Flow_5" sourceRef="Split" targetRef="CheckLaptopParts">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">include_laptop_parts = true</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=include_laptop_parts = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_7" sourceRef="CheckPrices" targetRef="Join" />
     <bpmn:inclusiveGateway id="Join" name="Join">

--- a/feel/lib/feel/feel.treetop
+++ b/feel/lib/feel/feel.treetop
@@ -370,7 +370,12 @@ grammar FEEL
     numeric_literal /
     string_literal /
     boolean_literal /
+    at_literal /
     date_time_literal
+  end
+
+  rule at_literal
+    "@" string_literal <AtLiteral>
   end
 
   #

--- a/feel/lib/feel/feel.treetop
+++ b/feel/lib/feel/feel.treetop
@@ -458,7 +458,7 @@ grammar FEEL
   # 40. function invocation = expression , parameters ;
   #
   rule function_invocation
-    fn_name:(!reserved_word qualified_name) __ "(" __ params:(positional_parameters)? __ ")" <FunctionInvocation>
+    fn_name:(!reserved_word qualified_name) __ "(" __ params:(positional_parameters)? __ ")" property:(__ "." __ name)? <FunctionInvocation>
   end
 
   #
@@ -628,7 +628,7 @@ grammar FEEL
   # 62. date time literal = ( "date" | "time" | "date and time" | "duration" ) , "(" , string literal , ")" ;
   #
   rule date_time_literal
-    keyword:date_time_keyword __ "(" __ head:expression __ tail:("," __ expression)* __ ")" <DateTimeLiteral>
+    keyword:date_time_keyword __ "(" __ head:expression __ tail:("," __ expression)* __ ")" property:(__ "." __ name)? <DateTimeLiteral>
   end
 
   rule date_time_keyword

--- a/feel/lib/feel/nodes.rb
+++ b/feel/lib/feel/nodes.rb
@@ -703,7 +703,7 @@ module FEEL
   class ContextEntryList < Node
     def eval(context = {})
       context_entries.inject({}) do |hash, entry|
-        hash.merge(entry.eval(context))
+        hash.merge(entry.eval(context.merge(hash)))
       end
     end
 

--- a/feel/lib/feel/nodes.rb
+++ b/feel/lib/feel/nodes.rb
@@ -427,6 +427,23 @@ module FEEL
     end
   end
 
+  class AtLiteral < Node
+    def eval(_context = {})
+      value = string_literal.eval
+      return nil if value.nil?
+      case value
+      when /\AP/
+        ActiveSupport::Duration.parse(value)
+      when /\A\d{4}-\d{2}-\d{2}T/
+        DateTime.parse(value)
+      when /\A\d{4}-\d{2}-\d{2}\z/
+        Date.parse(value)
+      when /\A\d{2}:\d{2}/
+        Time.parse(value)
+      end
+    end
+  end
+
   #
   # 38. digit = [0-9] ;
   #

--- a/feel/lib/feel/nodes.rb
+++ b/feel/lib/feel/nodes.rb
@@ -56,7 +56,11 @@ module FEEL
         when "seconds" then result.parts[:seconds] || 0
         end
       when Hash
-        result[property_name.to_sym] || result[property_name]
+        if result.key?(property_name.to_sym)
+          result[property_name.to_sym]
+        else
+          result[property_name]
+        end
       end
     end
 

--- a/feel/test/feel/literal_expression_test.rb
+++ b/feel/test/feel/literal_expression_test.rb
@@ -165,6 +165,10 @@ module FEEL
           _(LiteralExpression.new(text: '{ "a": 1, "b": 2 }').evaluate).must_equal({ "a" => 1, "b" => 2 })
         end
 
+        it "should allow entries to reference previous entries" do
+          _(LiteralExpression.new(text: '{"a": 2, "b": a * 2}').evaluate).must_equal({ "a" => 2, "b" => 4 })
+        end
+
         it "should handle null keys" do
           _(LiteralExpression.new(text: "{ null: 1 }").evaluate).must_equal({ nil => 1 })
         end

--- a/feel/test/feel/literal_expression_test.rb
+++ b/feel/test/feel/literal_expression_test.rb
@@ -134,6 +134,22 @@ module FEEL
           _(LiteralExpression.new(text: "duration(null)").evaluate).must_be_nil
           _(LiteralExpression.new(text: "date(missing_var)").evaluate).must_be_nil
         end
+
+        it "should eval @ literal dates" do
+          _(LiteralExpression.new(text: '@"2020-04-06"').evaluate).must_equal Date.new(2020, 4, 6)
+        end
+
+        it "should eval @ literal times" do
+          _(LiteralExpression.new(text: '@"08:00:00"').evaluate).must_be_kind_of Time
+        end
+
+        it "should eval @ literal date-times" do
+          _(LiteralExpression.new(text: '@"2020-04-06T08:00:00"').evaluate).must_be_kind_of DateTime
+        end
+
+        it "should eval @ literal durations" do
+          _(LiteralExpression.new(text: '@"P5D"').evaluate).must_equal 5.days
+        end
       end
 
       describe :list do

--- a/feel/test/feel/literal_expression_test.rb
+++ b/feel/test/feel/literal_expression_test.rb
@@ -121,10 +121,18 @@ module FEEL
         end
 
         it "should eval date properties" do
-          # _(FEEL.eval('date("1963-12-23").year')).must_equal 1963
-          # _(FEEL.eval('date("1963-12-23").month')).must_equal 12
-          # _(FEEL.eval('date("1963-12-23").day')).must_equal 23
-          # _(FEEL.eval('date("1963-12-23").weekday')).must_equal 1
+          _(LiteralExpression.new(text: 'date("1963-12-23").year').evaluate).must_equal 1963
+          _(LiteralExpression.new(text: 'date("1963-12-23").month').evaluate).must_equal 12
+          _(LiteralExpression.new(text: 'date("1963-12-23").day').evaluate).must_equal 23
+          _(LiteralExpression.new(text: 'date("1963-12-23").weekday').evaluate).must_equal 1
+        end
+
+        it "should eval duration properties" do
+          _(LiteralExpression.new(text: 'duration("P1Y6M").years').evaluate).must_equal 1
+          _(LiteralExpression.new(text: 'duration("P1Y6M").months').evaluate).must_equal 6
+          _(LiteralExpression.new(text: 'duration("P3DT6H30M").days').evaluate).must_equal 3
+          _(LiteralExpression.new(text: 'duration("P3DT6H30M").hours').evaluate).must_equal 6
+          _(LiteralExpression.new(text: 'duration("P3DT6H30M").minutes').evaluate).must_equal 30
         end
 
         it "should handle null values" do

--- a/feel/test/feel/literal_expression_test.rb
+++ b/feel/test/feel/literal_expression_test.rb
@@ -273,6 +273,10 @@ module FEEL
         _(LiteralExpression.new(text: " person.name ").evaluate(person: { name: "John" })).must_equal("John")
       end
 
+      it "should access falsy hash values" do
+        _(LiteralExpression.new(text: "data.active").evaluate(data: { active: false })).must_equal false
+      end
+
       describe :missing_identifiers do
         it "should return nil with simple identifier" do
           _(LiteralExpression.new(text: "name").evaluate).must_be_nil


### PR DESCRIPTION
- Treat expressions without a `=` prefix as static values per the [Camunda expression spec](https://docs.camunda.io/docs/components/concepts/expressions/)
- Add support for `@` literals, previous entry references, and simple property reading for Date/Time/DateTime/Duration/Hash types
- Handle nil expressions and falsey property values safely

Fixes #12