### PR TITLE
Add ItemDefinition class and update Definitions model attributes

### DIFF
--- a/bpmn/lib/bpmn/definitions.rb
+++ b/bpmn/lib/bpmn/definitions.rb
@@ -4,8 +4,12 @@ module BPMN
   class Definitions
     include ActiveModel::Model
 
+    MODEL_ATTRIBUTES = %i[
+      id name target_namespace exporter exporter_version execution_platform execution_platform_version
+    ].freeze
+
     attr_accessor :id, :name, :target_namespace, :exporter, :exporter_version, :execution_platform, :execution_platform_version
-    attr_reader :messages, :signals, :errors, :escalations, :processes
+    attr_reader :messages, :signals, :errors, :escalations, :item_definitions, :processes
 
     def self.from_xml(xml)
       XmlHasher.configure do |config|
@@ -22,12 +26,13 @@ module BPMN
     end
 
     def initialize(attributes={})
-      super(attributes.except(:message, :signal, :error, :escalation, :process))
+      super(attributes.slice(*MODEL_ATTRIBUTES))
 
       @messages = Array.wrap(attributes[:message]).map { |atts| Message.new(atts) }
       @signals = Array.wrap(attributes[:signal]).map { |atts| Signal.new(atts) }
       @errors = Array.wrap(attributes[:error]).map { |atts| Error.new(atts) }
       @escalations = Array.wrap(attributes[:escalation]).map { |atts| Escalation.new(atts) }
+      @item_definitions = Array.wrap(attributes[:item_definition]).map { |atts| ItemDefinition.new(atts) }
       @processes = Array.wrap(attributes[:process]).map { |atts| Process.new(atts) }
     end
 
@@ -51,8 +56,12 @@ module BPMN
       processes.find { |process| process.id == id }
     end
 
+    def item_definition_by_id(id)
+      item_definitions.find { |item| item.id == id }
+    end
+
     def inspect
-      "#<BPMN::Definitions @id=#{id.inspect} @name=#{name.inspect} @messages=#{messages.inspect} @signals=#{signals.inspect} @errors=#{errors.inspect} @escalations=#{escalations.inspect} @processes=#{processes.inspect}>"
+      "#<BPMN::Definitions @id=#{id.inspect} @name=#{name.inspect} @messages=#{messages.inspect} @signals=#{signals.inspect} @errors=#{errors.inspect} @escalations=#{escalations.inspect} @item_definitions=#{item_definitions.inspect} @processes=#{processes.inspect}>"
     end
   end
 end

--- a/bpmn/lib/bpmn/element.rb
+++ b/bpmn/lib/bpmn/element.rb
@@ -29,6 +29,15 @@ module BPMN
   class Escalation < Element
   end
 
+  class ItemDefinition < Element
+    attr_accessor :structure_ref
+
+    def initialize(attributes = {})
+      super(attributes)
+      @structure_ref = attributes[:structure_ref]
+    end
+  end
+
   class Collaboration < Element
   end
 


### PR DESCRIPTION
This pull request enhances the BPMN definitions to support `ItemDefinition` elements. The changes introduce a new `ItemDefinition` class, update the `Definitions` class to handle item definitions, and add a lookup method for item definitions by ID.

**Support for ItemDefinition elements:**

* Added a new `ItemDefinition` class to `bpmn/lib/bpmn/element.rb` with a `structure_ref` attribute and initialization logic.
* Updated the `Definitions` class in `bpmn/lib/bpmn/definitions.rb` to:
  * Include `item_definitions` as an attribute and initialize it from XML attributes. [[1]](diffhunk://#diff-e26abf50ce6ce02544c9d170b8d596a0e24e2cf6431acda16894f5ac517fa9c5R7-R12) [[2]](diffhunk://#diff-e26abf50ce6ce02544c9d170b8d596a0e24e2cf6431acda16894f5ac517fa9c5L25-R35)
  * Add a method `item_definition_by_id` for looking up item definitions by their ID.
  * Update the `inspect` method to include `item_definitions` in the output.

**Refactoring and consistency:**

* Centralized the list of model attributes for the `Definitions` class using the `MODEL_ATTRIBUTES` constant, and updated initialization to use `.slice` for clarity and maintainability. [[1]](diffhunk://#diff-e26abf50ce6ce02544c9d170b8d596a0e24e2cf6431acda16894f5ac517fa9c5R7-R12) [[2]](diffhunk://#diff-e26abf50ce6ce02544c9d170b8d596a0e24e2cf6431acda16894f5ac517fa9c5L25-R35)