### PR TITLE
FEEL Placeholder support: ? > 5

### DIFF
--- a/dmn/test/dmn/decision_table_test.rb
+++ b/dmn/test/dmn/decision_table_test.rb
@@ -63,5 +63,35 @@ module DMN
       result = decision_table.evaluate(variables)
       _(result).must_be_nil
     end
+
+    describe "? input placeholder" do
+      it "should match contains(?, ...) in input entries" do
+        definitions = Definitions.from_xml(fixture_source("test_input_placeholder.dmn"))
+        decision_table = definitions.decisions.first.decision_table
+        result = decision_table.evaluate(description: "This is urgent", priority: 1)
+        _(result).must_equal({ "action" => "Escalate" })
+      end
+
+      it "should match ? > n in input entries" do
+        definitions = Definitions.from_xml(fixture_source("test_input_placeholder.dmn"))
+        decision_table = definitions.decisions.first.decision_table
+        result = decision_table.evaluate(description: "Normal request", priority: 8)
+        _(result).must_equal({ "action" => "Review" })
+      end
+
+      it "should match starts with(?, ...) in input entries" do
+        definitions = Definitions.from_xml(fixture_source("test_input_placeholder.dmn"))
+        decision_table = definitions.decisions.first.decision_table
+        result = decision_table.evaluate(description: "Bug in login flow", priority: 2)
+        _(result).must_equal({ "action" => "Triage" })
+      end
+
+      it "should fall through to default when no placeholder matches" do
+        definitions = Definitions.from_xml(fixture_source("test_input_placeholder.dmn"))
+        decision_table = definitions.decisions.first.decision_table
+        result = decision_table.evaluate(description: "Normal request", priority: 3)
+        _(result).must_equal({ "action" => "Queue" })
+      end
+    end
   end
 end

--- a/dmn/test/dmn/decision_table_test.rb
+++ b/dmn/test/dmn/decision_table_test.rb
@@ -86,6 +86,20 @@ module DMN
         _(result).must_equal({ "action" => "Triage" })
       end
 
+      it "should match ? in both input entries of the same rule" do
+        definitions = Definitions.from_xml(fixture_source("test_input_placeholder.dmn"))
+        decision_table = definitions.decisions.first.decision_table
+        result = decision_table.evaluate(description: "A critical issue", priority: 4)
+        _(result).must_equal({ "action" => "Prioritize" })
+      end
+
+      it "should not match when only one ? input entry matches" do
+        definitions = Definitions.from_xml(fixture_source("test_input_placeholder.dmn"))
+        decision_table = definitions.decisions.first.decision_table
+        result = decision_table.evaluate(description: "A critical issue", priority: 2)
+        _(result).must_equal({ "action" => "Queue" })
+      end
+
       it "should fall through to default when no placeholder matches" do
         definitions = Definitions.from_xml(fixture_source("test_input_placeholder.dmn"))
         decision_table = definitions.decisions.first.decision_table

--- a/dmn/test/fixtures/files/test_input_placeholder.dmn
+++ b/dmn/test/fixtures/files/test_input_placeholder.dmn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="test_input_placeholder" name="Test Input Placeholder" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="service_request" name="Service Request">
+    <decisionTable id="DecisionTable_1" hitPolicy="FIRST">
+      <input id="Input_1" label="Description">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>description</text>
+        </inputExpression>
+      </input>
+      <input id="Input_2" label="Priority">
+        <inputExpression id="InputExpression_2" typeRef="number">
+          <text>priority</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Action" name="action" typeRef="string" />
+      <rule id="DecisionRule_1">
+        <inputEntry id="UnaryTests_1">
+          <text>contains(?, "urgent")</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_2">
+          <text>-</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1">
+          <text>"Escalate"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_2">
+        <inputEntry id="UnaryTests_3">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_4">
+          <text>? &gt; 5</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_2">
+          <text>"Review"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_3">
+        <inputEntry id="UnaryTests_5">
+          <text>starts with(?, "Bug")</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_6">
+          <text>-</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_3">
+          <text>"Triage"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_4">
+        <inputEntry id="UnaryTests_7">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_8">
+          <text>-</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_4">
+          <text>"Queue"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/dmn/test/fixtures/files/test_input_placeholder.dmn
+++ b/dmn/test/fixtures/files/test_input_placeholder.dmn
@@ -48,12 +48,23 @@
       </rule>
       <rule id="DecisionRule_4">
         <inputEntry id="UnaryTests_7">
-          <text>-</text>
+          <text>contains(?, "critical")</text>
         </inputEntry>
         <inputEntry id="UnaryTests_8">
-          <text>-</text>
+          <text>? &gt; 3</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_4">
+          <text>"Prioritize"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_5">
+        <inputEntry id="UnaryTests_9">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10">
+          <text>-</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_5">
           <text>"Queue"</text>
         </outputEntry>
       </rule>

--- a/feel/lib/feel/feel.treetop
+++ b/feel/lib/feel/feel.treetop
@@ -575,7 +575,7 @@ grammar FEEL
   # 51.d expression , "in" , " (", positive unary tests, ")" ;
   #
   rule comparison
-    left:non_recursive_simple_expression_for_comparison __ operator:comparision_operator __ right:expression <Comparison>
+    left:non_recursive_simple_expression_for_comparison __ operator:comparison_operator __ right:expression <Comparison>
   end
 
   rule non_recursive_simple_expression_for_comparison
@@ -590,7 +590,7 @@ grammar FEEL
     expression __ "[" __ filter:expression __ "]" <FilterExpression>
   end
 
-  rule comparision_operator
+  rule comparison_operator
     "=" / "!=" / "<=" / ">=" / "<" / ">"
   end
 

--- a/feel/lib/feel/feel.treetop
+++ b/feel/lib/feel/feel.treetop
@@ -245,6 +245,7 @@ grammar FEEL
     expr:simple_positive_unary_tests <SimpleUnaryTests> /
     negate:"not" __ "(" __ expr:simple_positive_unary_tests __ ")" <SimpleUnaryTests> /
     "-" <SimpleUnaryTests> /
+    # Handles ? in comparisons (e.g. "? > 5") — SimplePositiveUnaryTest handles ? in endpoints (e.g. "contains(?, \"x\")").
     expr:simple_expression <ExpressionUnaryTest>
   end
 

--- a/feel/lib/feel/feel.treetop
+++ b/feel/lib/feel/feel.treetop
@@ -179,7 +179,7 @@ grammar FEEL
   # 7.b interval ;
   #
   rule simple_positive_unary_test
-    head:((unary_operator / "not") __)? tail:endpoint <SimplePositiveUnaryTest> /
+    head:((unary_operator / "not") __)? tail:endpoint !(__ comparison_operator) <SimplePositiveUnaryTest> /
     interval
   end
 
@@ -244,7 +244,8 @@ grammar FEEL
   rule simple_unary_tests
     expr:simple_positive_unary_tests <SimpleUnaryTests> /
     negate:"not" __ "(" __ expr:simple_positive_unary_tests __ ")" <SimpleUnaryTests> /
-    "-" <SimpleUnaryTests>
+    "-" <SimpleUnaryTests> /
+    expr:simple_expression <ExpressionUnaryTest>
   end
 
   #
@@ -372,7 +373,7 @@ grammar FEEL
   # 30. name start char = "?" | [A-Z] | "\_" | [a-z] | [\uC0-\uD6] | [\uD8-\uF6] | [\uF8-\u2FF] | [\u370-\u37D] | [\u37F-\u1FFF] | [\u200C-\u200D] | [\u2070-\u218F] | [\u2C00-\u2FEF] | [\u3001-\uD7FF] | [\uF900-\uFDCF] | [\uFDF0-\uFFFD] | [\u10000-\uEFFFF] ;
   # 
   rule name_start_char
-    [A-Z] / [a-z] / "_" / name_start_unicode_char
+    "?" / [A-Z] / [a-z] / "_" / name_start_unicode_char
   end
 
   rule name_start_unicode_char

--- a/feel/lib/feel/nodes.rb
+++ b/feel/lib/feel/nodes.rb
@@ -125,6 +125,11 @@ module FEEL
   class SimplePositiveUnaryTest < Node
     def eval(context = {})
       operator = head.text_value.strip
+
+      if operator.empty? && text_value.include?("?")
+        return ->(input) { tail.eval(context.merge("?" => input)) }
+      end
+
       endpoint = tail.eval(context)
 
       case operator
@@ -239,6 +244,12 @@ module FEEL
       else
         ->(_input) { true }
       end
+    end
+  end
+
+  class ExpressionUnaryTest < Node
+    def eval(context = {})
+      ->(input) { expr.eval(context.merge("?" => input)) }
     end
   end
 

--- a/feel/lib/feel/nodes.rb
+++ b/feel/lib/feel/nodes.rb
@@ -2,6 +2,13 @@
 
 module FEEL
   class Node < Treetop::Runtime::SyntaxNode
+    def contains_input_placeholder?
+      return true if is_a?(Name) && text_value == "?"
+      return false unless respond_to?(:elements) && elements
+
+      elements.any? { |el| el.respond_to?(:contains_input_placeholder?) && el.contains_input_placeholder? }
+    end
+
     #
     # Takes a context hash and returns an array of qualified names
     # { "person": { "name": { "first": "Eric", "last": "Carlson" }, "age": 60 } } => ["person", "person.name.first", "person.name.last", "person.age"]
@@ -126,7 +133,7 @@ module FEEL
     def eval(context = {})
       operator = head.text_value.strip
 
-      if operator.empty? && text_value.include?("?")
+      if operator.empty? && tail.respond_to?(:contains_input_placeholder?) && tail.contains_input_placeholder?
         return ->(input) { tail.eval(context.merge("?" => input)) }
       end
 

--- a/feel/test/feel/unary_tests_test.rb
+++ b/feel/test/feel/unary_tests_test.rb
@@ -75,6 +75,44 @@ module FEEL
       end
     end
 
+    describe :input_value_placeholder do
+      it "should support ? in function invocations" do
+        _(UnaryTests.new(text: 'contains(?, "Garbage cart")').test("Garbage cart pickup")).must_equal true
+        _(UnaryTests.new(text: 'contains(?, "Garbage cart")').test("Recycling pickup")).must_equal false
+      end
+
+      it "should support ? in comparisons" do
+        _(UnaryTests.new(text: "? > 10").test(15)).must_equal true
+        _(UnaryTests.new(text: "? > 10").test(5)).must_equal false
+        _(UnaryTests.new(text: "? = 5").test(5)).must_equal true
+        _(UnaryTests.new(text: "? = 5").test(3)).must_equal false
+        _(UnaryTests.new(text: "? != 5").test(3)).must_equal true
+      end
+
+      it "should support ? in string functions" do
+        _(UnaryTests.new(text: 'starts with(?, "Hello")').test("Hello World")).must_equal true
+        _(UnaryTests.new(text: 'starts with(?, "Hello")').test("Goodbye")).must_equal false
+        _(UnaryTests.new(text: 'ends with(?, "World")').test("Hello World")).must_equal true
+      end
+
+      it "should support ? in arithmetic expressions" do
+        _(UnaryTests.new(text: "? + 5 > 10").test(6)).must_equal true
+        _(UnaryTests.new(text: "? + 5 > 10").test(4)).must_equal false
+      end
+
+      it "should support ? in comma-separated tests" do
+        _(UnaryTests.new(text: 'contains(?, "a"), contains(?, "b")').test("apple")).must_equal true
+        _(UnaryTests.new(text: 'contains(?, "a"), contains(?, "b")').test("banana")).must_equal true
+        _(UnaryTests.new(text: 'contains(?, "a"), contains(?, "b")').test("cherry")).must_equal false
+      end
+
+      it "should be valid" do
+        _(UnaryTests.new(text: 'contains(?, "x")').valid?).must_equal true
+        _(UnaryTests.new(text: "? > 10").valid?).must_equal true
+        _(UnaryTests.new(text: "? + 5 > 10").valid?).must_equal true
+      end
+    end
+
     describe :null_handling do
       it "should not match null input in comparisons" do
         _(UnaryTests.new(text: "< 4").test(nil)).must_equal false

--- a/feel/test/feel/unary_tests_test.rb
+++ b/feel/test/feel/unary_tests_test.rb
@@ -106,6 +106,11 @@ module FEEL
         _(UnaryTests.new(text: 'contains(?, "a"), contains(?, "b")').test("cherry")).must_equal false
       end
 
+      it "should not treat ? inside a string literal as an input placeholder" do
+        _(UnaryTests.new(text: 'string length("?")').test(1)).must_equal true
+        _(UnaryTests.new(text: 'string length("?")').test(2)).must_equal false
+      end
+
       it "should be valid" do
         _(UnaryTests.new(text: 'contains(?, "x")').valid?).must_equal true
         _(UnaryTests.new(text: "? > 10").valid?).must_equal true


### PR DESCRIPTION
Modifies the FEEL parser to support the ? placeholder in unary tests, allowing it to handle previously inexpressible tests:

`contains(?, "urgent")`

It represents the value under test. Equivalent to the modern `it` in Ruby.

From [DMN 1.5 Spec](https://www.omg.org/spec/DMN/1.5/PDF).
> 7.3.2 UnaryTests Metamodel
The class UnaryTests is used to model a boolean test where the argument to be tested is implicit or denoted with a ?, and whose value is specified by text in some specified expression language.