### PR TITLE
Support external form reference

### DIFF
--- a/bpmn/lib/bpmn/extensions.rb
+++ b/bpmn/lib/bpmn/extensions.rb
@@ -28,7 +28,7 @@ module Zeebe
   end
 
   class FormDefinition < BPMN::Extension
-    attr_accessor :form_key
+    attr_accessor :form_key, :external_reference
   end
 
   class IoMapping < BPMN::Extension


### PR DESCRIPTION
External form references cause exeception while parsing schema