### PR TITLE
Support camunda native (Zeebe) user tasks

### DIFF
--- a/bpmn/lib/bpmn/extensions.rb
+++ b/bpmn/lib/bpmn/extensions.rb
@@ -28,7 +28,7 @@ module Zeebe
   end
 
   class FormDefinition < BPMN::Extension
-    attr_accessor :form_key
+    attr_accessor :form_key, :form_id, :external_reference
   end
 
   class IoMapping < BPMN::Extension

--- a/bpmn/lib/bpmn/task.rb
+++ b/bpmn/lib/bpmn/task.rb
@@ -38,6 +38,14 @@ module BPMN
       extension_elements&.form_definition&.form_key
     end
 
+    def form_id
+      extension_elements&.form_definition&.form_id
+    end
+
+    def external_reference
+      extension_elements&.form_definition&.external_reference
+    end
+
     def assignee
       extension_elements&.assignment_definition&.assignee
     end

--- a/bpmn/test/bpmn/extension_test.rb
+++ b/bpmn/test/bpmn/extension_test.rb
@@ -11,6 +11,8 @@ module BPMN
       let(:process) { context.process_by_id("ZeebeExtensionsTest") }
       let(:start_event) { process.element_by_id("Start") }
       let(:user_task) { process.element_by_id("UserTask") }
+      let(:user_task_form_id) { process.element_by_id("UserTaskFormID") }
+      let(:user_task_external) { process.element_by_id("UserTaskExternal") }
       let(:business_rule_task) { process.element_by_id("BusinessRuleTask") }
       let(:service_task) { process.element_by_id("ServiceTask") }
       let(:script_task) { process.element_by_id("ScriptTask") }
@@ -45,11 +47,21 @@ module BPMN
         end
       end
 
-      describe :form_definition do
+      describe :form_definition_job_worker do
         let(:form_definition) { user_task.extension_elements.form_definition }
 
-        it "should parse the form definition" do
+        it "should parse the job worker form definition" do
           _(form_definition.form_key).must_equal "some_form"
+        end
+      end
+
+      describe :form_definition_camunda_form do
+        let(:form_definition_form_id) { user_task_form_id.extension_elements.form_definition }
+        let(:form_definition_external) { user_task_external.extension_elements.form_definition }
+
+        it "should parse the camunda form definition" do
+          _(form_definition_form_id.form_id).must_equal "form_id"
+          _(form_definition_external.external_reference).must_equal "external_reference"
         end
       end
 

--- a/bpmn/test/fixtures/files/extension_elements_test.bpmn
+++ b/bpmn/test/fixtures/files/extension_elements_test.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1cxr0ze" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.25.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1cxr0ze" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.47.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
   <bpmn:process id="ZeebeExtensionsTest" name="Zeebe Extensions Test" isExecutable="true">
     <bpmn:extensionElements>
       <zeebe:properties>
@@ -27,7 +27,7 @@
       <bpmn:incoming>Flow_1af1ejk</bpmn:incoming>
       <bpmn:outgoing>Flow_03gm2bi</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:sequenceFlow id="Flow_03gm2bi" sourceRef="UserTask" targetRef="BusinessRuleTask" />
+    <bpmn:sequenceFlow id="Flow_03gm2bi" sourceRef="UserTask" targetRef="UserTaskFormID" />
     <bpmn:serviceTask id="ServiceTask" name="Service Task">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="service_type" retries="3" />
@@ -59,7 +59,7 @@
       <bpmn:extensionElements>
         <zeebe:calledDecision decisionId="ChooseGreeting" resultVariable="greeting" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_03gm2bi</bpmn:incoming>
+      <bpmn:incoming>Flow_0w8oh0p</bpmn:incoming>
       <bpmn:outgoing>Flow_0pi8qk3</bpmn:outgoing>
     </bpmn:businessRuleTask>
     <bpmn:sequenceFlow id="Flow_1ojgpfy" sourceRef="CallActivity" targetRef="End" />
@@ -70,6 +70,24 @@
       <bpmn:incoming>Flow_11057uk</bpmn:incoming>
       <bpmn:outgoing>Flow_1ojgpfy</bpmn:outgoing>
     </bpmn:callActivity>
+    <bpmn:userTask id="UserTaskFormID" name="UserTaskFormID">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="form_id" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_03gm2bi</bpmn:incoming>
+      <bpmn:outgoing>Flow_01vg661</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_01vg661" sourceRef="UserTaskFormID" targetRef="UserTaskExternal" />
+    <bpmn:sequenceFlow id="Flow_0w8oh0p" sourceRef="UserTaskExternal" targetRef="BusinessRuleTask" />
+    <bpmn:userTask id="UserTaskExternal" name="UserTaskExternal">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition externalReference="external_reference" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_01vg661</bpmn:incoming>
+      <bpmn:outgoing>Flow_0w8oh0p</bpmn:outgoing>
+    </bpmn:userTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ZeebeExtensionsTest">
@@ -83,26 +101,33 @@
         <dc:Bounds x="270" y="77" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15pmxuc_di" bpmnElement="UserTaskFormID">
+        <dc:Bounds x="420" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0wdm9si_di" bpmnElement="ServiceTask">
-        <dc:Bounds x="590" y="77" width="100" height="80" />
+        <dc:Bounds x="880" y="77" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0f2495f_di" bpmnElement="ScriptTask">
-        <dc:Bounds x="750" y="77" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ibn43x_di" bpmnElement="BusinessRuleTask">
-        <dc:Bounds x="430" y="77" width="100" height="80" />
+        <dc:Bounds x="1040" y="77" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_11qxxsx_di" bpmnElement="End">
-        <dc:Bounds x="1052" y="99" width="36" height="36" />
+        <dc:Bounds x="1342" y="99" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1060" y="142" width="20" height="14" />
+          <dc:Bounds x="1350" y="142" width="20" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ibn43x_di" bpmnElement="BusinessRuleTask">
+        <dc:Bounds x="720" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0hmql9j_di" bpmnElement="CallActivity">
-        <dc:Bounds x="910" y="77" width="100" height="80" />
+        <dc:Bounds x="1200" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1vh7qml_di" bpmnElement="UserTaskExternal">
+        <dc:Bounds x="570" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1af1ejk_di" bpmnElement="Flow_1af1ejk">
         <di:waypoint x="215" y="117" />
@@ -110,23 +135,31 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_03gm2bi_di" bpmnElement="Flow_03gm2bi">
         <di:waypoint x="370" y="117" />
-        <di:waypoint x="430" y="117" />
+        <di:waypoint x="420" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_142xjob_di" bpmnElement="Flow_142xjob">
-        <di:waypoint x="690" y="117" />
-        <di:waypoint x="750" y="117" />
+        <di:waypoint x="980" y="117" />
+        <di:waypoint x="1040" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_11057uk_di" bpmnElement="Flow_11057uk">
-        <di:waypoint x="850" y="117" />
-        <di:waypoint x="910" y="117" />
+        <di:waypoint x="1140" y="117" />
+        <di:waypoint x="1200" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0pi8qk3_di" bpmnElement="Flow_0pi8qk3">
-        <di:waypoint x="530" y="117" />
-        <di:waypoint x="590" y="117" />
+        <di:waypoint x="820" y="117" />
+        <di:waypoint x="880" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ojgpfy_di" bpmnElement="Flow_1ojgpfy">
-        <di:waypoint x="1010" y="117" />
-        <di:waypoint x="1052" y="117" />
+        <di:waypoint x="1300" y="117" />
+        <di:waypoint x="1342" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01vg661_di" bpmnElement="Flow_01vg661">
+        <di:waypoint x="520" y="117" />
+        <di:waypoint x="570" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0w8oh0p_di" bpmnElement="Flow_0w8oh0p">
+        <di:waypoint x="670" y="117" />
+        <di:waypoint x="720" y="117" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Add support for parsing schemas with camunda native (8.5+) user tasks. Currently only job worker user tasks are supported