### PR TITLE
Cleanup unused DMN methods, fix docs, improve verbosity

### DIFF
--- a/bpmn/lib/bpmn/execution.rb
+++ b/bpmn/lib/bpmn/execution.rb
@@ -216,7 +216,7 @@ module BPMN
       return nil if expression.nil?
 
       if expression.start_with?("=")
-        DMN.evaluate(expression.delete_prefix("="), variables: variables)
+        FEEL.evaluate(expression.delete_prefix("="), variables: variables)
       else
         expression
       end
@@ -393,10 +393,14 @@ module BPMN
     end
 
     def print_child(child, index)
-      str = "#{index} #{child.step.class.name.demodulize} #{child.step.id}: #{child.status} #{JSON.pretty_generate(child.variables, { indent: '', object_nl: ' ' }) unless child.variables.empty? }".strip
+      vars = child.variables.empty? ? '' : JSON.pretty_generate(child.variables, { indent: '', object_nl: ' ' })
+      step = child.step
+
+      str = "#{index} #{step.class.name.demodulize} #{step.id} \"#{step.name}\": #{child.status} #{vars}".strip
       str = "#{str} * in: #{child.tokens_in.join(', ')}" if child.tokens_in.present?
       str = "#{str} * out: #{child.tokens_out.join(', ')}" if child.tokens_out.present?
       puts str
+
       child.children.each_with_index do |grandchild, grandindex|
         print_child(grandchild, "#{index}.#{grandindex}")
       end

--- a/bpmn/lib/bpmn/execution.rb
+++ b/bpmn/lib/bpmn/execution.rb
@@ -394,9 +394,9 @@ module BPMN
 
     def print_child(child, index)
       vars = child.variables.empty? ? '' : JSON.pretty_generate(child.variables, { indent: '', object_nl: ' ' })
-      step = child.step
+      name = child.step.name.present? ? " <#{child.step.name}>" : ""
 
-      str = "#{index} #{step.class.name.demodulize} #{step.id} \"#{step.name}\": #{child.status} #{vars}".strip
+      str = "#{index} #{child.step.class.name.demodulize} #{child.step.id}#{name}: #{child.status} #{vars}".strip
       str = "#{str} * in: #{child.tokens_in.join(', ')}" if child.tokens_in.present?
       str = "#{str} * out: #{child.tokens_out.join(', ')}" if child.tokens_out.present?
       puts str

--- a/dmn/README.md
+++ b/dmn/README.md
@@ -2,7 +2,7 @@
 
 A light-weight DMN (Decision Model and Notation) business rule ruby gem.
 
-This gem depends on the [FEEL](https://github.com/connectedbits/bpmn/tree/main/feel) gem to evaluate DMN decision tables and expressions.
+This gem depends on the [FEEL](https://github.com/connectedbits/workflow-kit/tree/main/feel) gem to evaluate DMN decision tables and expressions.
 
 ## Usage
 

--- a/dmn/lib/dmn.rb
+++ b/dmn/lib/dmn.rb
@@ -27,18 +27,6 @@ module DMN
   class SyntaxError < StandardError; end
   class EvaluationError < StandardError; end
 
-  def self.evaluate(expression_text, variables: {})
-    literal_expression = FEEL::LiteralExpression.new(text: expression_text)
-    raise SyntaxError, "Expression is not valid" unless literal_expression.valid?
-    literal_expression.evaluate(variables)
-  end
-
-  def self.test(input, unary_tests_text, variables: {})
-    unary_tests = FEEL::UnaryTests.new(text: unary_tests_text)
-    raise SyntaxError, "Unary tests are not valid" unless unary_tests.valid?
-    unary_tests.test(input, variables)
-  end
-
   def self.decide(decision_id, definitions: nil, definitions_json: nil, definitions_xml: nil, variables: {})
     if definitions_xml.present?
       definitions = DMN::Definitions.from_xml(definitions_xml)

--- a/feel/README.md
+++ b/feel/README.md
@@ -59,7 +59,7 @@ Calling a user-defined function:
 FEEL.config.functions = {
   "reverse": ->(s) { s.reverse }
 }
-DMN.evaluate('reverse("Hello World!")', functions:)
+FEEL.evaluate('reverse("Hello World!")')
 # => "!dlroW olleH"
 ```
 
@@ -137,6 +137,10 @@ UnaryTests.new(text: '> speed - speed_limit').variable_names
 - [x] List: `list contains`, `count`, `min`, `max`, `sum`, `product`, `mean`, `median`, `stddev`, `mode`, `all`, `any`, `sublist`, `append`, `concatenate`, `insert before`, `remove`, `reverse`, `index of`, `union`, `distinct values`, `duplicate values`, `flatten`, `sort`, `string join`
 - [x] Context: `get entries`, `get value`, `get keys`
 - [x] Temporal: `now`, `today`, `day of week`, `day of year`, `month of year`, `week of year`
+
+### Comments
+- [ ] Single-line
+- [ ] Multi-line
 
 ## Installation
 

--- a/feel/lib/feel.rb
+++ b/feel/lib/feel.rb
@@ -26,13 +26,13 @@ module FEEL
 
   def self.evaluate(expression_text, variables: {})
     literal_expression = FEEL::LiteralExpression.new(text: expression_text)
-    raise SyntaxError, "Expression is not valid" unless literal_expression.valid?
+    raise SyntaxError, "Expression is not valid: #{expression_text}" unless literal_expression.valid?
     literal_expression.evaluate(variables)
   end
 
   def self.test(input, unary_tests_text, variables: {})
     unary_tests = FEEL::UnaryTests.new(text: unary_tests_text)
-    raise SyntaxError, "Unary tests are not valid" unless unary_tests.valid?
+    raise SyntaxError, "Unary tests are not valid: #{unary_tests_text}" unless unary_tests.valid?
     unary_tests.test(input, variables)
   end
 


### PR DESCRIPTION
1. Remove `DMN.decide`, `DMN.test` methods as those are nor documented neither tested. They seemed to be hitstorical artifacts.
2. Fix doc errors
3. Improve FEEL exception messages and execution print output